### PR TITLE
Optimize uint128_t::getString()

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,9 @@
 
 # git master
 
+* [68](https://github.com/HBPVis/Servus/pull/68):
+  Optimize uint128_t::getString()
+
 # Release 1.5 (09-12-2016)
 
 * [64](https://github.com/HBPVis/Servus/pull/64):

--- a/servus/types.h
+++ b/servus/types.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016, Human Brain Project
+/* Copyright (c) 2015-2017, Human Brain Project
  *                          Stefan.Eilemann@epfl.ch
  *                          Juan Hernando <jhernando@fi.upm.es>
  *
@@ -56,6 +56,7 @@ class Servus;
 class URI;
 class uint128_t;
 
+typedef unsigned long long ull_t;
 typedef std::vector< std::string > Strings;
 }
 

--- a/servus/uint128_t.h
+++ b/servus/uint128_t.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010-2016, Cedric Stalder <cedric.stalder@gmail.com>
+/* Copyright (c) 2010-2017, Cedric Stalder <cedric.stalder@gmail.com>
  *                          Stefan Eilemann <eile@eyescale.ch>
  *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
@@ -22,6 +22,7 @@
 #define SERVUS_UINT128_H
 
 #include <servus/api.h>
+#include <servus/types.h>
 
 #include <sstream>
 #ifdef _MSC_VER
@@ -235,13 +236,9 @@ public:
     /** @return the full string representation of the value. */
     std::string getString() const
     {
-        // OPT: snprintf is faster then using std::stringstream
-        char buffer[ 34 ] /* 16 bytes + : + \0 */;
-#ifdef _MSC_VER
-        snprintf( buffer, 34, "%llx:%llx", high(), low( ));
-#else
-        snprintf( buffer, 34, "%lx:%lx", high(), low( ));
-#endif
+        // OPT: snprintf is faster than using std::stringstream
+        char buffer[ 34 ] /* 2 x 16 bytes + : + \0 */;
+        snprintf( buffer, 34, "%llx:%llx", ull_t( high( )), ull_t( low( )));
         return std::string( buffer );
     }
 

--- a/servus/uint128_t.h
+++ b/servus/uint128_t.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010-2015, Cedric Stalder <cedric.stalder@gmail.com>
+/* Copyright (c) 2010-2016, Cedric Stalder <cedric.stalder@gmail.com>
  *                          Stefan Eilemann <eile@eyescale.ch>
  *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
@@ -224,21 +224,26 @@ public:
 
     /** @return a short, but not necessarily unique, string of the value. */
     std::string getShortString() const
-        {
-            std::stringstream stream;
-            stream << std::hex << _high << _low;
-            const std::string str = stream.str();
-            return str.substr( 0, 3 ) + ".." +
-                str.substr( str.length() - 3, std::string::npos );
-        }
+    {
+        std::stringstream stream;
+        stream << std::hex << _high << _low;
+        const std::string str = stream.str();
+        return str.substr( 0, 3 ) + ".." +
+               str.substr( str.length() - 3, std::string::npos );
+    }
 
     /** @return the full string representation of the value. */
     std::string getString() const
-        {
-            std::stringstream stream;
-            stream << *this;
-            return stream.str();
-        }
+    {
+        // OPT: snprintf is faster then using std::stringstream
+        char buffer[ 34 ] /* 16 bytes + : + \0 */;
+#ifdef _MSC_VER
+        snprintf( buffer, 34, "%llx:%llx", high(), low( ));
+#else
+        snprintf( buffer, 34, "%lx:%lx", high(), low( ));
+#endif
+        return std::string( buffer );
+    }
 
     /** Serialize this object to a boost archive. */
     template< class Archive >


### PR DESCRIPTION
Shows up in memcached keyv::Map, which uses this per key, in one
benchmark as 35s vs 43s.