### PR TITLE
Failsafe when Servus implementation can't created and fallback to dummy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ add_subdirectory(apps)
 add_subdirectory(tests)
 
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
-set(SERVUS_DEBIAN_PACKAGE_DEPENDS)
+set(SERVUS_PACKAGE_DEB_DEPENDS)
 if (avahi-client_FOUND)
   list(APPEND SERVUS_PACKAGE_DEB_DEPENDS libavahi-client3 avahi-daemon)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,10 @@ add_subdirectory(apps)
 add_subdirectory(tests)
 
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libavahi-client3, avahi-daemon")
+set(SERVUS_DEBIAN_PACKAGE_DEPENDS)
+if (avahi-client_FOUND)
+  list(APPEND SERVUS_PACKAGE_DEB_DEPENDS libavahi-client3 avahi-daemon)
+endif()
 include(CommonCPack)
 
 set(COMMON_PROJECT_DOMAIN eu.humanbrainproject)

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@
 
 # git master
 
+* [80](https://github.com/HBPVis/Servus/pull/80):
+  Failsafe when Servus implementation can't be created and fallback to dummy.
 * [77](https://github.com/HBPVis/Servus/pull/77):
   Add test driver implementation for Servus
 * [76](https://github.com/HBPVis/Servus/pull/76):

--- a/servus/servus.cpp
+++ b/servus/servus.cpp
@@ -193,12 +193,21 @@ std::unique_ptr<Servus::Impl> _chooseImplementation(const std::string& name)
 {
     if (name == TEST_DRIVER)
         return std::unique_ptr<Servus::Impl>(new test::Servus);
+    try
+    {
 #ifdef SERVUS_USE_DNSSD
-    return std::unique_ptr<Servus::Impl>(new dnssd::Servus(name));
+        return std::unique_ptr<Servus::Impl>(new dnssd::Servus(name));
 #elif defined(SERVUS_USE_AVAHI_CLIENT)
-    return std::unique_ptr<Servus::Impl>(new avahi::Servus(name));
+        return std::unique_ptr<Servus::Impl>(new avahi::Servus(name));
 #endif
-    return std::unique_ptr<Servus::Impl>(new none::Servus(name));
+        return std::unique_ptr<Servus::Impl>(new none::Servus(name));
+    }
+    catch (const std::runtime_error& error)
+    {
+        std::cerr << "Error starting Servus client: " << error.what()
+                  << std::endl;
+        return std::unique_ptr<Servus::Impl>(new servus::none::Servus(name));
+    }
 }
 }
 


### PR DESCRIPTION
This is needed for the nix build, which is complied with avahi support, but when run somewhere where the avahi daemon is not running it crashes whatever application uses Servus.