### PR TITLE
Fix compilation using clang 5.0 on Ubuntu 16.04

### DIFF
--- a/tests/itemModel.cpp
+++ b/tests/itemModel.cpp
@@ -50,7 +50,7 @@ class Watchdog
 {
 public:
     Watchdog()
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__clang__)
         : gotUpdate(false)
 #else
         : gotUpdate(ATOMIC_VAR_INIT(false))


### PR DESCRIPTION
It fixes this error I got:
```
/home/jkarlsso/Work/Servus/tests/itemModel.cpp:56:21: error: braces around scalar initializer
      [-Werror,-Wbraced-scalar-init]
        : gotUpdate(ATOMIC_VAR_INIT(false))
                    ^~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/atomic_base.h:123:30: note: expanded
      from macro 'ATOMIC_VAR_INIT'
#define ATOMIC_VAR_INIT(_VI) { _VI }
                             ^~~~~~~
1 error generated.
```