### PR TITLE
Added iterator header needed on MSVC compilations

### DIFF
--- a/servus/test/servus.h
+++ b/servus/test/servus.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <mutex>
 #include <set>
+#include <iterator>
 
 namespace servus
 {


### PR DESCRIPTION
Hello, I'm Gonzalo Bayo, from the group working back in URJC/UPM with Pablo Toharia.
Right now I would like to use Servus in a custom C++ project in Windows (VC14) and “/Servus/servus/test/servus.h” doesn't compile. I have got the error: C3861 'back_inserter': identifier not found.
The error can be fixed including the following header: `#include <iterator>` at the top of the file.
Regards