### PR TITLE
add Servus::getPort()

### DIFF
--- a/servus/avahi/servus.h
+++ b/servus/avahi/servus.h
@@ -313,16 +313,16 @@ private:
     static void _resolveCBS(AvahiServiceResolver* resolver, AvahiIfIndex,
                             AvahiProtocol, AvahiResolverEvent event,
                             const char* name, const char*, const char*,
-                            const char* host, const AvahiAddress*, uint16_t,
+                            const char* host, const AvahiAddress*, uint16_t port,
                             AvahiStringList* txt, AvahiLookupResultFlags flags,
                             void* servus)
     {
-        ((Servus*)servus)->_resolveCB(resolver, event, name, host, txt, flags);
+        ((Servus*)servus)->_resolveCB(resolver, event, name, host, port, txt, flags);
     }
 
     void _resolveCB(AvahiServiceResolver* resolver,
                     const AvahiResolverEvent event, const char* name,
-                    const char* host, AvahiStringList* txt,
+                    const char* host, uint16_t port, AvahiStringList* txt,
                     const AvahiLookupResultFlags flags)
     {
         // If browsing through the local interface, consider only the local
@@ -342,6 +342,7 @@ private:
         {
             ValueMap& values = _instanceMap[name];
             values["servus_host"] = host;
+            values["servus_port"] = std::to_string(static_cast<int>(port));
             for (; txt; txt = txt->next)
             {
                 const std::string entry(reinterpret_cast<const char*>(

--- a/servus/dnssd/servus.h
+++ b/servus/dnssd/servus.h
@@ -294,19 +294,20 @@ private:
     static void DNSSD_API resolveCBS_(DNSServiceRef, DNSServiceFlags,
                             uint32_t /*interfaceIdx*/,
                             DNSServiceErrorType error, const char* /*name*/,
-                            const char* host, uint16_t /*port*/,
+                            const char* host, uint16_t port,
                             uint16_t txtLen, const unsigned char* txt,
                             Servus* servus)
     {
         if (error == kDNSServiceErr_NoError)
-            servus->resolveCB_(host, txtLen, txt);
+            servus->resolveCB_(host, port, txtLen, txt);
         servus->_result = error;
     }
 
-    void resolveCB_(const char* host, uint16_t txtLen, const unsigned char* txt)
+    void resolveCB_(const char* host, uint16_t port, uint16_t txtLen, const unsigned char* txt)
     {
         ValueMap& values = _instanceMap[_browsedName];
         values["servus_host"] = host;
+        values["servus_port"] = std::to_string(static_cast<int>(port));
 
         char key[256] = {0};
         const char* value = 0;

--- a/servus/servus.cpp
+++ b/servus/servus.cpp
@@ -369,6 +369,19 @@ const std::string& Servus::getHost(const std::string& instance) const
     return get(instance, "servus_host");
 }
 
+uint16_t Servus::getPort(const std::string& instance) const
+{
+  std::string sport = get(instance, "servus_port");
+  try {
+    const int port = std::stoi (sport);
+    if (port < 0 || port > 0xFFFF)
+      return 0;
+    return static_cast<uint16_t>(port);
+  } catch (const std::exception&) {
+    return 0;
+  }
+}
+
 bool Servus::containsKey(const std::string& instance,
                          const std::string& key) const
 {

--- a/servus/servus.h
+++ b/servus/servus.h
@@ -178,6 +178,9 @@ public:
     /** @return the host corresponding to the given instance. @version 1.3 */
     SERVUS_API const std::string& getHost(const std::string& instance) const;
 
+    /** @return the port corresponding to the given instance. @version 1.6 */
+    SERVUS_API uint16_t getPort(const std::string& instance) const;
+
     /** @return true if the given key was discovered. @version 1.1 */
     SERVUS_API bool containsKey(const std::string& instance,
                                 const std::string& key) const;

--- a/tests/itemModel.cpp
+++ b/tests/itemModel.cpp
@@ -178,15 +178,17 @@ BOOST_AUTO_TEST_CASE(servusItemModel)
         model.data(instanceIndex, Qt::UserRole).toString().toStdString(),
         service.get(TEST_INSTANCE, "servus_host"));
     BOOST_CHECK(model.data(instanceIndex, Qt::EditRole) == QVariant());
-    BOOST_REQUIRE_EQUAL(model.rowCount(instanceIndex), 2);
+    BOOST_REQUIRE_EQUAL(model.rowCount(instanceIndex), 3);
     const QModelIndex kv1Index = model.index(0, 0, instanceIndex);
     BOOST_CHECK(model.parent(kv1Index) == instanceIndex);
     BOOST_CHECK(model.data(kv1Index, Qt::UserRole) == QVariant());
     const QVariant kv1 = model.data(kv1Index);
     const QVariant kv2 = model.data(model.index(1, 0, instanceIndex));
+    const QVariant kv3 = model.data(model.index(2, 0, instanceIndex));
     BOOST_REQUIRE_EQUAL(model.rowCount(kv1Index), 0);
     BOOST_CHECK_EQUAL(kv1.toString().toStdString(), "foo = bar");
     BOOST_CHECK(kv2.toString().startsWith("servus_host = "));
+    BOOST_CHECK(kv3.toString().startsWith("servus_port = "));
 
     WatchRemove watchRemove;
     service.addListener(&watchRemove);


### PR DESCRIPTION
the port information is stored in 'servus_port' (as a string), but is returned as an `unsigned short` by `Servus::getPort()`.

Closes: https://github.com/HBPVIS/Servus/issues/109